### PR TITLE
Configuring projects to use appSettings and user-secrets.

### DIFF
--- a/M02-create-plugins-for-semantic-kernel/M02-Project/M02-Project.csproj
+++ b/M02-create-plugins-for-semantic-kernel/M02-Project/M02-Project.csproj
@@ -6,10 +6,20 @@
     <RootNamespace>M02_Project</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <UserSecretsId>55c9d37c-975b-4483-842a-0f625fa89011</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.17.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/M02-create-plugins-for-semantic-kernel/M02-Project/Program.cs
+++ b/M02-create-plugins-for-semantic-kernel/M02-Project/Program.cs
@@ -1,9 +1,16 @@
 ﻿#pragma warning disable SKEXP0050 
+using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
 
-string yourDeploymentName = "";
-string yourEndpoint = "";
-string yourApiKey = "";
+var config = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddUserSecrets<Program>(optional: true)
+    .Build();
+
+// Set your values in appsettings.json or user secrets
+string yourDeploymentName = config.GetRequiredSection("yourDeploymentName").Value!;
+string yourEndpoint = config.GetRequiredSection("yourEndpoint").Value!;
+string yourApiKey = config.GetRequiredSection("yourApiKey").Value!;
 
 var builder = Kernel.CreateBuilder();
 builder.AddAzureOpenAIChatCompletion(

--- a/M02-create-plugins-for-semantic-kernel/M02-Project/appsettings.json
+++ b/M02-create-plugins-for-semantic-kernel/M02-Project/appsettings.json
@@ -1,0 +1,5 @@
+{
+    "yourDeploymentName": "",
+    "yourEndpoint": "",
+    "yourApiKey": ""
+}

--- a/M03-give-your-ai-agent-skills/M03-Project/M03-Project.csproj
+++ b/M03-give-your-ai-agent-skills/M03-Project/M03-Project.csproj
@@ -6,11 +6,20 @@
     <RootNamespace>M03_Project</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	<UserSecretsId>55c9d37c-975b-4483-842a-0f625fa89011</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.2.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.2.0-alpha" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.SemanticKernel" Version="1.17.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/M03-give-your-ai-agent-skills/M03-Project/Program.cs
+++ b/M03-give-your-ai-agent-skills/M03-Project/Program.cs
@@ -1,8 +1,15 @@
-﻿using Microsoft.SemanticKernel;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
 
-string yourDeploymentName = "";
-string yourEndpoint = "";
-string yourApiKey = "";
+var config = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddUserSecrets<Program>(optional: true)
+    .Build();
+
+// Set your values in appsettings.json or user secrets
+string yourDeploymentName = config.GetRequiredSection("yourDeploymentName").Value!;
+string yourEndpoint = config.GetRequiredSection("yourEndpoint").Value!;
+string yourApiKey = config.GetRequiredSection("yourApiKey").Value!;
 
 var builder = Kernel.CreateBuilder();
 builder.AddAzureOpenAIChatCompletion(

--- a/M03-give-your-ai-agent-skills/M03-Project/appsettings.json
+++ b/M03-give-your-ai-agent-skills/M03-Project/appsettings.json
@@ -1,0 +1,5 @@
+{
+    "yourDeploymentName": "",
+    "yourEndpoint": "",
+    "yourApiKey": ""
+}

--- a/M04-combine-prompts-and-functions/M04-Project/M04-Project.csproj
+++ b/M04-combine-prompts-and-functions/M04-Project/M04-Project.csproj
@@ -6,11 +6,34 @@
     <RootNamespace>M04_Project</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	<UserSecretsId>55c9d37c-975b-4483-842a-0f625fa89011</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.2.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.2.0-alpha" />
+    <None Remove="data\musiclibrary.txt" />
+    <None Remove="data\recentlyplayed.txt" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="data\musiclibrary.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="data\recentlyplayed.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.SemanticKernel" Version="1.17.2" />
+  </ItemGroup>
+
+	<ItemGroup>
+		<None Update="appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/M04-combine-prompts-and-functions/M04-Project/Program.cs
+++ b/M04-combine-prompts-and-functions/M04-Project/Program.cs
@@ -1,8 +1,15 @@
-﻿using Microsoft.SemanticKernel;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
 
-string yourDeploymentName = "";
-string yourEndpoint = "";
-string yourApiKey = "";
+var config = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddUserSecrets<Program>(optional: true)
+    .Build();
+
+// Set your values in appsettings.json or user secrets
+string yourDeploymentName = config.GetRequiredSection("yourDeploymentName").Value!;
+string yourEndpoint = config.GetRequiredSection("yourEndpoint").Value!;
+string yourApiKey = config.GetRequiredSection("yourApiKey").Value!;
 
 var builder = Kernel.CreateBuilder();
 builder.AddAzureOpenAIChatCompletion(

--- a/M04-combine-prompts-and-functions/M04-Project/appsettings.json
+++ b/M04-combine-prompts-and-functions/M04-Project/appsettings.json
@@ -1,0 +1,5 @@
+{
+    "yourDeploymentName": "",
+    "yourEndpoint": "",
+    "yourApiKey": ""
+}

--- a/M05-use-intelligent-planners/M05-Project/M05-Project.csproj
+++ b/M05-use-intelligent-planners/M05-Project/M05-Project.csproj
@@ -6,12 +6,38 @@
     <RootNamespace>M05_Project</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	<UserSecretsId>55c9d37c-975b-4483-842a-0f625fa89011</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.2.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Planners.Handlebars" Version="1.2.0-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.2.0-alpha" />
+    <None Remove="data\concertdates.txt" />
+    <None Remove="data\musiclibrary.txt" />
+    <None Remove="data\recentlyplayed.txt" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="data\concertdates.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="data\musiclibrary.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="data\recentlyplayed.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.17.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/M05-use-intelligent-planners/M05-Project/Program.cs
+++ b/M05-use-intelligent-planners/M05-Project/Program.cs
@@ -1,8 +1,15 @@
-﻿using Microsoft.SemanticKernel;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
 
-string yourDeploymentName = "";
-string yourEndpoint = "";
-string yourApiKey = "";
+var config = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddUserSecrets<Program>(optional: true)
+    .Build();
+
+// Set your values in appsettings.json or user secrets
+string yourDeploymentName = config.GetRequiredSection("yourDeploymentName").Value!;
+string yourEndpoint = config.GetRequiredSection("yourEndpoint").Value!;
+string yourApiKey = config.GetRequiredSection("yourApiKey").Value!;
 
 var builder = Kernel.CreateBuilder();
 builder.AddAzureOpenAIChatCompletion(

--- a/M05-use-intelligent-planners/M05-Project/appsettings.json
+++ b/M05-use-intelligent-planners/M05-Project/appsettings.json
@@ -1,0 +1,5 @@
+{
+    "yourDeploymentName": "",
+    "yourEndpoint": "",
+    "yourApiKey": ""
+}

--- a/MSLearn-Develop-AI-Agents-with-Azure-OpenAI-and-Semantic-Kernel-SDK.sln
+++ b/MSLearn-Develop-AI-Agents-with-Azure-OpenAI-and-Semantic-Kernel-SDK.sln
@@ -3,9 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "M02-create-plugins-for-semantic-kernel", "M02-create-plugins-for-semantic-kernel", "{B87147B4-79CB-451B-9599-8167209A8826}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "M02-Project", "M02-create-plugins-for-semantic-kernel\M02-Project\M02-Project.csproj", "{63D9E15F-AD7B-4B07-BE46-35B3A9D3101B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "M03-Project", "M03-give-your-ai-agent-skills\M03-Project\M03-Project.csproj", "{BF372B36-B81C-43BF-8526-1F84686DDF63}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "M04-Project", "M04-combine-prompts-and-functions\M04-Project\M04-Project.csproj", "{CD254420-241B-42C8-9278-34ABE62DABD5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "M05-Project", "M05-use-intelligent-planners\M05-Project\M05-Project.csproj", "{0CC5B437-39C5-42B2-90AD-FD3D7059E0A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,12 +21,21 @@ Global
 		{63D9E15F-AD7B-4B07-BE46-35B3A9D3101B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63D9E15F-AD7B-4B07-BE46-35B3A9D3101B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63D9E15F-AD7B-4B07-BE46-35B3A9D3101B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF372B36-B81C-43BF-8526-1F84686DDF63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF372B36-B81C-43BF-8526-1F84686DDF63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF372B36-B81C-43BF-8526-1F84686DDF63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF372B36-B81C-43BF-8526-1F84686DDF63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD254420-241B-42C8-9278-34ABE62DABD5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD254420-241B-42C8-9278-34ABE62DABD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD254420-241B-42C8-9278-34ABE62DABD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD254420-241B-42C8-9278-34ABE62DABD5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CC5B437-39C5-42B2-90AD-FD3D7059E0A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CC5B437-39C5-42B2-90AD-FD3D7059E0A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CC5B437-39C5-42B2-90AD-FD3D7059E0A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CC5B437-39C5-42B2-90AD-FD3D7059E0A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{63D9E15F-AD7B-4B07-BE46-35B3A9D3101B} = {B87147B4-79CB-451B-9599-8167209A8826}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4CBB0488-497A-40CD-984E-A4BD57CF3A29}


### PR DESCRIPTION
The Semantic Kernel team gives live customer sessions using the projects in this repo and is important that we can do this without leaking sensitive information such as model endpoint and keys. This PR addresses this by making the following changes:

- Add `ConfigurationBuilder` support that can read configuration from `appSettings.json` or `user-secrets`. This will allow the presenter in the sessions to use user-secrets while the learners can use the `appSettings.json` for easy startup.
- Added all of the projects to the shared solution for easy access.
- Added data files used in M04 and M05 projects to output. This fixes runtime issues with reading from these files.
- Updated SemanticKernel to latest version.