### PR TITLE
fix wrong path of appsettings.json in M02

### DIFF
--- a/M02-create-plugins-for-semantic-kernel/M02-Project/Program.cs
+++ b/M02-create-plugins-for-semantic-kernel/M02-Project/Program.cs
@@ -3,7 +3,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 
-string filePath = Path.GetFullPath("../../appsettings.json");
+string filePath = Path.GetFullPath("../appsettings.json");
 var config = new ConfigurationBuilder()
     .AddJsonFile(filePath)
     .Build();


### PR DESCRIPTION
I found the file path is wrong in M02 module. 
![image](https://github.com/user-attachments/assets/d038b195-13f2-471e-9691-7784d3d95a9a)

After fixing this, I still cannot run the program by `dotnet run`. It warned me:

```
Couldn't find a project to run. Ensure a project exists in /Users/wenwei/Desktop/dev/learn/MSLearn-Develop-AI-Agents-with-Azure-OpenAI-and-Semantic-Kernel-SDK/M02-create-plugins-for-semantic-kernel, or pass the path to the project using --project.
```
I used .NET 9 to run this project. Does it cause the issue?

But with the following command, I can run the project:

```
dotnet run --project M02-Project
```